### PR TITLE
Fix MongoDB version checker to use the command "buildInfo" [#38]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+* Fix MongoDB version checker to use the command "buildInfo", which is more lightweight and without any timestamp type [#38] (https://github.com/nosinovacao/name-sdk/issues/38)
 
 ## v1.2.0 - 2018-08-09
 ### Added

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <Authors>NOS Inovação</Authors>
     <PackageTags>NOS NAME NOS Api Manifest Extension name nos api manifest extension</PackageTags>

--- a/src/NAME/MongoDb/MongoDBVersionResolver.cs
+++ b/src/NAME/MongoDb/MongoDBVersionResolver.cs
@@ -121,7 +121,7 @@ namespace NAME.MongoDb
 
                 var commandBSON = new BSONObject
                 {
-                    ["serverStatus"] = 1.0
+                    ["buildInfo"] = 1.0
                 };
                 commandWriter.Write(SimpleBSON.Dump(commandBSON));
                 commandWriter.Flush();


### PR DESCRIPTION
Fix MongoDB version checker to use the command "buildInfo" which is more lightweight and without any timestamp type [#38]

Bump version to 1.2.1